### PR TITLE
card.URL domain is 0.0.0.0 is auto replace requested domain

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -1,5 +1,23 @@
 package a2a
 
+import (
+	"net/http"
+	"strings"
+)
+
 func Ptr[T any](v T) *T {
 	return &v
+}
+
+func isHTTPS(r *http.Request) bool {
+	if r.TLS != nil {
+		return true
+	}
+	if proto := r.Header.Get("X-Forwarded-Proto"); proto != "" {
+		return strings.EqualFold(proto, "https")
+	}
+	if fwd := r.Header.Get("Forwarded"); strings.Contains(strings.ToLower(fwd), "proto=https") {
+		return true
+	}
+	return false
 }


### PR DESCRIPTION
This pull request introduces a new feature to allow conditional replacement of the host in the `AgentCard` URL based on a flag, along with a utility function to determine if a request is using HTTPS. The most important changes include adding the `IgnoreReplaceHost` flag to the `Handler` and `HandlerOptions` structs, modifying the `handleAgentCard` method to respect this flag, and adding a new `isHTTPS` utility function.

### Feature: Conditional Host Replacement in `AgentCard` URL

* **Added `IgnoreReplaceHost` flag to `Handler` struct**: Introduced a new boolean field `ignoreReplaceHost` in the `Handler` struct to control whether the host replacement logic is applied. (`handler.go`, [handler.goR50](diffhunk://#diff-0eb779b9e49d8e44b0f36923fdb8d87d5ee024f886eefc45deec4ec88380a087R50))
* **Added `IgnoreReplaceHost` to `HandlerOptions`**: Updated the `HandlerOptions` struct to include the `IgnoreReplaceHost` flag, with documentation explaining its purpose and default behavior. (`handler.go`, [handler.goR108-R112](diffhunk://#diff-0eb779b9e49d8e44b0f36923fdb8d87d5ee024f886eefc45deec4ec88380a087R108-R112))
* **Integrated `IgnoreReplaceHost` in `NewHandler`**: Modified the `NewHandler` constructor to initialize the `ignoreReplaceHost` field based on the `HandlerOptions`. (`handler.go`, [handler.goR224](diffhunk://#diff-0eb779b9e49d8e44b0f36923fdb8d87d5ee024f886eefc45deec4ec88380a087R224))
* **Updated `handleAgentCard` method**: Enhanced the `handleAgentCard` method to conditionally replace the host in the `AgentCard` URL if the current host is `0.0.0.0` and the `ignoreReplaceHost` flag is not set. (`handler.go`, [handler.goR275-R287](diffhunk://#diff-0eb779b9e49d8e44b0f36923fdb8d87d5ee024f886eefc45deec4ec88380a087R275-R287))

### Utility: HTTPS Detection

* **Added `isHTTPS` function**: Implemented a utility function `isHTTPS` in `utils.go` to determine if a request is using HTTPS by checking the `TLS` field and relevant headers (`X-Forwarded-Proto` and `Forwarded`). (`utils.go`, [utils.goR3-R23](diffhunk://#diff-8b7f25bac2ae04c2ce2abb628c6aa28103fd113103a62f3e9d232fa995684915R3-R23))