### PR TITLE
update store interface, history is not session scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,10 +88,9 @@ The `Store` interface manages tasks and their associated data. If the server ope
 
 ```go
 type Store interface {
-	GetHistory(ctx context.Context, taskID string, historyLength int) ([]Message, error)
+	UpsertTask(ctx context.Context, params TaskSendParams) (*Task, error)
+	GetTask(ctx context.Context, taskID string, historyLength *int) (*Task, error)
 	AppendHistory(ctx context.Context, taskID string, message Message) error
-	CreateTask(ctx context.Context, task *Task) error
-	GetTask(ctx context.Context, taskID string) (*Task, error)
 	UpdateStatus(ctx context.Context, taskID string, status TaskStatus) error
 	UpdateArtifact(ctx context.Context, taskID string, artifact Artifact) error
 }

--- a/README.md
+++ b/README.md
@@ -88,8 +88,8 @@ The `Store` interface manages tasks and their associated data. If the server ope
 
 ```go
 type Store interface {
-	GetHistory(ctx context.Context, sessionID string, historyLength int) ([]Message, error)
-	AppendHistory(ctx context.Context, sessionID string, message Message) error
+	GetHistory(ctx context.Context, taskID string, historyLength int) ([]Message, error)
+	AppendHistory(ctx context.Context, taskID string, message Message) error
 	CreateTask(ctx context.Context, task *Task) error
 	GetTask(ctx context.Context, taskID string) (*Task, error)
 	UpdateStatus(ctx context.Context, taskID string, status TaskStatus) error

--- a/core_objects.go
+++ b/core_objects.go
@@ -168,6 +168,9 @@ func (t *Task) Validate() error {
 			return err
 		}
 	}
+	if t.Metadata == nil {
+		t.Metadata = make(map[string]any)
+	}
 	return nil
 }
 
@@ -207,6 +210,9 @@ func (e *TaskStatusUpdateEvent) Validate() error {
 	if err := e.Status.Validate(); err != nil {
 		return err
 	}
+	if e.Metadata == nil {
+		e.Metadata = make(map[string]any)
+	}
 	return nil
 }
 
@@ -224,6 +230,9 @@ func (e *TaskArtifactUpdateEvent) Validate() error {
 	}
 	if err := e.Artifact.Validate(); err != nil {
 		return err
+	}
+	if e.Metadata == nil {
+		e.Metadata = make(map[string]any)
 	}
 	return nil
 }
@@ -309,6 +318,9 @@ func (p *TaskIDParams) Validate() error {
 	if p.ID == "" {
 		return errors.New("id is required")
 	}
+	if p.Metadata == nil {
+		p.Metadata = make(map[string]any)
+	}
 	return nil
 }
 
@@ -319,6 +331,9 @@ func (p *TaskSendParams) Validate() error {
 	}
 	if err := p.Message.Validate(); err != nil {
 		return err
+	}
+	if p.Metadata == nil {
+		p.Metadata = make(map[string]any)
 	}
 	if p.PushNotification != nil {
 		if err := p.PushNotification.Validate(); err != nil {
@@ -340,6 +355,34 @@ const (
 	TaskStateFailed        TaskState = "failed"
 	TaskStateUnknown       TaskState = "unknown"
 )
+
+func (s TaskState) String() string {
+	switch s {
+	case TaskStateSubmitted:
+		return "submitted"
+	case TaskStateWorking:
+		return "working"
+	case TaskStateInputRequired:
+		return "input-required"
+	case TaskStateCompleted:
+		return "completed"
+	case TaskStateCanceled:
+		return "canceled"
+	case TaskStateFailed:
+		return "failed"
+	default:
+		return "unknown"
+	}
+}
+
+func (s TaskState) Final() bool {
+	switch s {
+	case TaskStateCompleted, TaskStateCanceled, TaskStateFailed, TaskStateInputRequired:
+		return true
+	default:
+		return false
+	}
+}
 
 // Artifact represents an artifact created by the agent.
 type Artifact struct {
@@ -388,6 +431,9 @@ func (m *Message) Validate() error {
 		if err := part.Validate(); err != nil {
 			return err
 		}
+	}
+	if m.Metadata == nil {
+		m.Metadata = make(map[string]any)
 	}
 	return nil
 }
@@ -524,6 +570,9 @@ func (t *TaskPushNotificationConfig) Validate() error {
 	}
 	if err := t.PushNotificationConfig.Validate(); err != nil {
 		return err
+	}
+	if t.Metadata == nil {
+		t.Metadata = make(map[string]any)
 	}
 	return nil
 }

--- a/core_objects_test.go
+++ b/core_objects_test.go
@@ -15,7 +15,8 @@ func TestStreamingEventMarshalUnmarshal(t *testing.T) {
 			Status: TaskStatus{
 				State: TaskStateWorking,
 			},
-			Final: true,
+			Final:    true,
+			Metadata: make(map[string]any),
 		},
 	}
 
@@ -40,6 +41,7 @@ func TestStreamingEventMarshalUnmarshal(t *testing.T) {
 				},
 				Index: 0,
 			},
+			Metadata: make(map[string]any),
 		},
 	}
 

--- a/handler_test.go
+++ b/handler_test.go
@@ -68,7 +68,7 @@ func TestHandler_TasksSendSync(t *testing.T) {
 		)
 		tr.SetStatus(ctx, TaskStatus{
 			State: TaskStateCompleted,
-		}, true, nil)
+		}, nil)
 		return nil
 	})
 	handler, err := NewHandler(
@@ -158,7 +158,7 @@ func TestHandler_TasksSendAsync(t *testing.T) {
 		// Start asynchronous processing
 		tr.SetStatus(ctx, TaskStatus{
 			State: TaskStateWorking,
-		}, false, nil)
+		}, nil)
 
 		wg.Add(1) // Increment WaitGroup counter
 		go func() {
@@ -176,7 +176,7 @@ func TestHandler_TasksSendAsync(t *testing.T) {
 			)
 			tr.SetStatus(ctx, TaskStatus{
 				State: TaskStateCompleted,
-			}, true, nil)
+			}, nil)
 		}()
 		return nil
 	})
@@ -276,7 +276,7 @@ func TestHandler_TasksCancel(t *testing.T) {
 		// Start background processing
 		tr.SetStatus(ctx, TaskStatus{
 			State: TaskStateWorking,
-		}, true, nil)
+		}, nil)
 
 		wg.Add(1) // Increment WaitGroup counter
 		go func() {
@@ -289,7 +289,7 @@ func TestHandler_TasksCancel(t *testing.T) {
 			case <-time.After(5 * time.Second): // Simulate long-running task
 				tr.SetStatus(ctx, TaskStatus{
 					State: TaskStateCompleted,
-				}, true, nil)
+				}, nil)
 			}
 		}()
 		return nil
@@ -402,7 +402,7 @@ func TestHandler_TasksSendSubscribeSync(t *testing.T) {
 		)
 		tr.SetStatus(ctx, TaskStatus{
 			State: TaskStateCompleted,
-		}, true, nil)
+		}, nil)
 		return nil
 	})
 	handler, err := NewHandler(
@@ -500,7 +500,7 @@ func TestHandler_TasksResubscribe(t *testing.T) {
 					TextPart("Waiting Ready"),
 				},
 			},
-		}, false, nil)
+		}, nil)
 		wg.Add(1)
 		go func() {
 			ctx := context.Background()
@@ -516,7 +516,7 @@ func TestHandler_TasksResubscribe(t *testing.T) {
 						TextPart("Processing..."),
 					},
 				},
-			}, false, nil)
+			}, nil)
 			// Finalize with Completed state and an artifact
 			tr.WriteArtifact(ctx, Artifact{
 				Index: 2,
@@ -526,7 +526,7 @@ func TestHandler_TasksResubscribe(t *testing.T) {
 			}, nil)
 			tr.SetStatus(ctx, TaskStatus{
 				State: TaskStateCompleted,
-			}, true, nil)
+			}, nil)
 		}()
 		return nil
 	})
@@ -661,7 +661,7 @@ func TestHandler_TasksPushNotification(t *testing.T) {
 		// Start background processing
 		tr.SetStatus(ctx, TaskStatus{
 			State: TaskStateWorking,
-		}, true, nil)
+		}, nil)
 
 		wg.Add(1)
 		go func() {
@@ -680,7 +680,7 @@ func TestHandler_TasksPushNotification(t *testing.T) {
 			)
 			tr.SetStatus(ctx, TaskStatus{
 				State: TaskStateCompleted,
-			}, true, nil)
+			}, nil)
 		}()
 		return nil
 	})
@@ -794,12 +794,12 @@ func TestHandler_MultiTurnConversation(t *testing.T) {
 						TextPart("I am test agent, who are you?"),
 					},
 				},
-			}, true, nil)
+			}, nil)
 		} else {
 			// Second turn: return Completed
 			tr.SetStatus(ctx, TaskStatus{
 				State: TaskStateCompleted,
-			}, true, nil)
+			}, nil)
 		}
 		return nil
 	})

--- a/store.go
+++ b/store.go
@@ -9,9 +9,9 @@ import (
 // Store defines the interface for managing tasks and their associated data.
 type Store interface {
 	// UpsertTask creates or updates a task in the store.
-	// If the task already exists, it will be append message to the task's history and update metadata.
-	// If the task does not exist, it will create a new task. status is submitted.
-	// return the task with the updated.
+	// If the task already exists, it appends a message to the task's history and updates its metadata.
+	// If the task does not exist, it creates a new task with a "submitted" status.
+	// Returns the task with the applied updates.
 	UpsertTask(ctx context.Context, params TaskSendParams) (*Task, error)
 
 	// GetTask retrieves a task by its ID.

--- a/store.go
+++ b/store.go
@@ -8,18 +8,17 @@ import (
 
 // Store defines the interface for managing tasks and their associated data.
 type Store interface {
-	// GetHistory retrieves the message history for a given session ID.
-	// If historyLength is negative, all messages are returned.
-	GetHistory(ctx context.Context, sessionID string, historyLength int) ([]Message, error)
-
-	// AppendHistory appends a message to the history of a given session ID.
-	AppendHistory(ctx context.Context, sessionID string, message Message) error
-
-	// CreateTask creates a new task in the store.
-	CreateTask(ctx context.Context, task *Task) error
+	// UpsertTask creates or updates a task in the store.
+	// If the task already exists, it will be append message to the task's history and update metadata.
+	// If the task does not exist, it will create a new task. status is submitted.
+	// return the task with the updated.
+	UpsertTask(ctx context.Context, params TaskSendParams) (*Task, error)
 
 	// GetTask retrieves a task by its ID.
-	GetTask(ctx context.Context, taskID string) (*Task, error)
+	GetTask(ctx context.Context, taskID string, historyLength *int) (*Task, error)
+
+	// AppendHistory appends a message to the history of a given task ID.
+	AppendHistory(ctx context.Context, taskID string, message Message) error
 
 	// UpdateStatus updates the status of a task by its ID.
 	UpdateStatus(ctx context.Context, taskID string, status TaskStatus) error
@@ -37,12 +36,69 @@ type PushNotificationStore interface {
 	GetTaskPushNotification(ctx context.Context, taskID string) (*TaskPushNotificationConfig, error)
 }
 
+// MutateTask is utility function for implementing the Store interface.
+// if cur is nil, it will return the new task.
+// if cur is not nil, it will return the updated task.
+func MutateTask(cur *Task, params TaskSendParams) *Task {
+	if cur == nil {
+		task := &Task{
+			ID:       params.ID,
+			Metadata: params.Metadata,
+			Status: TaskStatus{
+				State: TaskStateSubmitted,
+			},
+			History: []Message{
+				params.Message,
+			},
+			Artifacts: []Artifact{},
+		}
+		if params.SessionID != nil {
+			task.SessionID = *params.SessionID
+		}
+		return task
+	}
+	if cur.Status.State == TaskStateCompleted {
+		return cur
+	}
+	cloned := *cur
+	// Update the task with the new parameters
+	for k, v := range params.Metadata {
+		if v == nil {
+			delete(cloned.Metadata, k)
+		} else {
+			cloned.Metadata[k] = v
+		}
+	}
+	cloned.History = append(cloned.History, params.Message)
+	return &cloned
+}
+
+// TruncateHistory is utility function for implementing the Store interface.
+// it will truncate the history of the task to the specified length.
+// if length is negative, it will return all messages.
+// if length is nil, it will return the task as is.
+// if length is 0, it will return the task with an empty history.
+// if length is greater than the current history length, truncate and return only last N messages.
+func TruncateHistory(task *Task, length *int) *Task {
+	cloned := *task
+	if length == nil || *length < 0 {
+		return &cloned
+	}
+	if *length == 0 {
+		cloned.History = []Message{}
+		return &cloned
+	}
+	if len(cloned.History) > *length {
+		cloned.History = append([]Message{}, cloned.History[len(cloned.History)-*length:]...)
+	}
+	return &cloned
+}
+
 // InMemoryStore is an in-memory implementation of the Store and PushNotificationStore interfaces.
 type InMemoryStore struct {
 	mu                sync.RWMutex
 	initOnce          sync.Once
 	tasks             map[string]*Task
-	history           map[string][]Message
 	pushNotifications map[string]*TaskPushNotificationConfig
 }
 
@@ -50,64 +106,44 @@ type InMemoryStore struct {
 func (s *InMemoryStore) init() {
 	s.initOnce.Do(func() {
 		s.tasks = make(map[string]*Task)
-		s.history = make(map[string][]Message)
 		s.pushNotifications = make(map[string]*TaskPushNotificationConfig)
 	})
 }
 
 // CreateTask creates a new task in the in-memory store.
-func (s *InMemoryStore) CreateTask(ctx context.Context, task *Task) error {
+func (s *InMemoryStore) UpsertTask(ctx context.Context, params TaskSendParams) (*Task, error) {
 	s.init()
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	//clone task
-	cloned := *task
-	s.tasks[task.ID] = &cloned
-	return nil
+	cur := s.tasks[params.ID]
+	stored := MutateTask(cur, params)
+	s.tasks[params.ID] = stored
+	return TruncateHistory(stored, params.HistoryLength), nil
 }
 
 // GetTask retrieves a task by its ID from the in-memory store.
-func (s *InMemoryStore) GetTask(ctx context.Context, taskID string) (*Task, error) {
+func (s *InMemoryStore) GetTask(ctx context.Context, taskID string, historyLength *int) (*Task, error) {
 	s.init()
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	if task, ok := s.tasks[taskID]; ok {
-		// clone task
-		cloned := *task
-		return &cloned, nil
+		return TruncateHistory(task, historyLength), nil
 	}
 	return nil, ErrTaskNotFound
 }
 
-// AppendHistory appends a message to the history of a given session ID.
-func (s *InMemoryStore) AppendHistory(ctx context.Context, sessionID string, message Message) error {
+// AppendHistory appends a message to the history of a given task ID.
+func (s *InMemoryStore) AppendHistory(ctx context.Context, taskID string, message Message) error {
 	s.init()
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if _, ok := s.history[sessionID]; !ok {
-		s.history[sessionID] = []Message{}
+	task, ok := s.tasks[taskID]
+	if !ok {
+		return ErrTaskNotFound
 	}
-	s.history[sessionID] = append(s.history[sessionID], message)
+	task.History = append(task.History, message)
+	s.tasks[taskID] = task
 	return nil
-}
-
-// GetHistory retrieves the message history for a given session ID.
-// If historyLength is negative, all messages are returned.
-func (s *InMemoryStore) GetHistory(ctx context.Context, sessionID string, historyLength int) ([]Message, error) {
-	s.init()
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-	if messages, ok := s.history[sessionID]; ok {
-		if historyLength < 0 {
-			return messages, nil
-		}
-		// return the last N messages
-		if len(messages) > historyLength {
-			return messages[len(messages)-historyLength:], nil
-		}
-		return messages, nil
-	}
-	return []Message{}, nil
 }
 
 // UpdateStatus updates the status of a task by its ID.


### PR DESCRIPTION
This pull request introduces several changes to improve task handling, metadata management, and the overall code structure. Key updates include replacing `sessionID` with `taskID` for task history operations, ensuring metadata is always initialized, simplifying handler logic, and enhancing task state management. Additionally, redundant code and parameters have been removed to streamline functionality.

### Task and Metadata Management:

* Replaced `sessionID` with `taskID` in `Store` interface methods to align with task-centric operations (`README.md`, `core_objects.go`, `responder.go`). [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L91-R92) [[2]](diffhunk://#diff-d423371206870c274f93e6da9c6976865b7238016127fdbbf4cbeae0a60090fcL62-R70)
* Added logic to initialize `Metadata` as an empty map if it is `nil` in multiple `Validate` methods (`core_objects.go`). [[1]](diffhunk://#diff-9b6012f7b499017be439e95885ab44b5ad10f81323dddaae0571efb9bca86d7bR171-R173) [[2]](diffhunk://#diff-9b6012f7b499017be439e95885ab44b5ad10f81323dddaae0571efb9bca86d7bR213-R215) [[3]](diffhunk://#diff-9b6012f7b499017be439e95885ab44b5ad10f81323dddaae0571efb9bca86d7bR234-R236) [[4]](diffhunk://#diff-9b6012f7b499017be439e95885ab44b5ad10f81323dddaae0571efb9bca86d7bR321-R323) [[5]](diffhunk://#diff-9b6012f7b499017be439e95885ab44b5ad10f81323dddaae0571efb9bca86d7bR335-R337) [[6]](diffhunk://#diff-9b6012f7b499017be439e95885ab44b5ad10f81323dddaae0571efb9bca86d7bR435-R437) [[7]](diffhunk://#diff-9b6012f7b499017be439e95885ab44b5ad10f81323dddaae0571efb9bca86d7bR574-R576)

### Task State Management:

* Introduced `TaskState.String()` and `TaskState.Final()` methods to simplify state handling and determine if a state is final (`core_objects.go`).
* Updated task polling logic to use the `Final()` method for determining task completion (`handler.go`).

### Handler and Responder Simplifications:

* Removed `AgentHistoryLength` parameter and related logic from `HandlerOptions` and `Handler` methods (`handler.go`). [[1]](diffhunk://#diff-0eb779b9e49d8e44b0f36923fdb8d87d5ee024f886eefc45deec4ec88380a087L101-L104) [[2]](diffhunk://#diff-0eb779b9e49d8e44b0f36923fdb8d87d5ee024f886eefc45deec4ec88380a087L150-L153) [[3]](diffhunk://#diff-0eb779b9e49d8e44b0f36923fdb8d87d5ee024f886eefc45deec4ec88380a087L222)
* Simplified `SetStatus` method in `TaskResponder` by removing the `final` parameter and deriving it from the task state (`responder.go`). [[1]](diffhunk://#diff-d423371206870c274f93e6da9c6976865b7238016127fdbbf4cbeae0a60090fcL11-R11) [[2]](diffhunk://#diff-d423371206870c274f93e6da9c6976865b7238016127fdbbf4cbeae0a60090fcL52-R52) [[3]](diffhunk://#diff-d423371206870c274f93e6da9c6976865b7238016127fdbbf4cbeae0a60090fcL62-R70)

### Test Updates:

* Updated tests to reflect changes in metadata initialization and `SetStatus` method signature (`core_objects_test.go`, `handler_test.go`). [[1]](diffhunk://#diff-9cf9a83ff767efbc503a4615140d6df06c9a83f9135569d30c1d29d5b58e134fR19) [[2]](diffhunk://#diff-39de3493ae7887b6c07ddf65fc59c005b3f2fccc9b06da022954597de5b12d7cL71-R71) [[3]](diffhunk://#diff-39de3493ae7887b6c07ddf65fc59c005b3f2fccc9b06da022954597de5b12d7cL161-R161) [[4]](diffhunk://#diff-39de3493ae7887b6c07ddf65fc59c005b3f2fccc9b06da022954597de5b12d7cL405-R405) [[5]](diffhunk://#diff-39de3493ae7887b6c07ddf65fc59c005b3f2fccc9b06da022954597de5b12d7cL797-R802)

### Code Cleanup:

* Removed redundant history fetching and task creation logic in `processTask` and `onGetTask` methods (`handler.go`). [[1]](diffhunk://#diff-0eb779b9e49d8e44b0f36923fdb8d87d5ee024f886eefc45deec4ec88380a087L429-L443) [[2]](diffhunk://#diff-0eb779b9e49d8e44b0f36923fdb8d87d5ee024f886eefc45deec4ec88380a087R879) [[3]](diffhunk://#diff-0eb779b9e49d8e44b0f36923fdb8d87d5ee024f886eefc45deec4ec88380a087R888-R894)