### PR TITLE
add task in incoming message

### DIFF
--- a/core_objects.go
+++ b/core_objects.go
@@ -142,6 +142,7 @@ type Task struct {
 	ID        string         `json:"id"`
 	SessionID string         `json:"sessionId"`
 	Status    TaskStatus     `json:"status"`
+	Message   *Message       `json:"-"` // incoming message on tasks/send or tasks/sendSubscribe
 	History   []Message      `json:"history,omitempty"`
 	Artifacts []Artifact     `json:"artifacts,omitempty"`
 	Metadata  map[string]any `json:"metadata,omitempty"`

--- a/handler.go
+++ b/handler.go
@@ -894,6 +894,7 @@ func (h *Handler) processTask(ctx context.Context, httpReq *http.Request, rpcReq
 			}
 		}
 	}()
+	task.Message = &params.Message
 	tr := h.NewTaskResponder(task.ID)
 	if err := h.agent.Invoke(cctx, tr, task); err != nil {
 		h.logger().WarnContext(ctx, "Failed to invoke agent", "error", err, "task_id", task.ID)


### PR DESCRIPTION
This pull request introduces a new `Message` field to the `Task` struct in `core_objects.go` and updates the `processTask` method in `handler.go` to populate this field when processing tasks. These changes aim to enhance task handling by associating incoming messages with tasks.

### Enhancements to Task Handling:

* [`core_objects.go`](diffhunk://#diff-9b6012f7b499017be439e95885ab44b5ad10f81323dddaae0571efb9bca86d7bR145): Added a new `Message` field to the `Task` struct, which is a pointer to a `Message`. This field is not serialized (`json:"-"`) and is intended to store incoming messages for tasks.

* [`handler.go`](diffhunk://#diff-0eb779b9e49d8e44b0f36923fdb8d87d5ee024f886eefc45deec4ec88380a087R897): Updated the `processTask` method to assign the incoming message (`params.Message`) to the newly added `Message` field in the `Task` struct.