### PR TITLE
SSE Response Close, if state is Final

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -711,7 +711,7 @@ func (h *Handler) writeSSE(ctx context.Context, w http.ResponseWriter, rpcReq *j
 		if fetchErr != nil {
 			return
 		}
-		if event.StatusUpdated != nil && event.StatusUpdated.Status.State.Final() {
+		if event.StatusUpdated != nil && event.StatusUpdated.Status != nil && event.StatusUpdated.Status.State.Final() {
 			h.logger().DebugContext(ctx, "Final state reached", "task_id", event.StatusUpdated.ID)
 			return
 		}

--- a/handler.go
+++ b/handler.go
@@ -711,7 +711,7 @@ func (h *Handler) writeSSE(ctx context.Context, w http.ResponseWriter, rpcReq *j
 		if fetchErr != nil {
 			return
 		}
-		if event.StatusUpdated != nil && event.StatusUpdated.Status != nil && event.StatusUpdated.Status.State.Final() {
+		if event.StatusUpdated != nil && event.StatusUpdated.Status.State.Final() {
 			h.logger().DebugContext(ctx, "Final state reached", "task_id", event.StatusUpdated.ID)
 			return
 		}

--- a/handler.go
+++ b/handler.go
@@ -711,6 +711,10 @@ func (h *Handler) writeSSE(ctx context.Context, w http.ResponseWriter, rpcReq *j
 		if fetchErr != nil {
 			return
 		}
+		if event.StatusUpdated != nil && event.StatusUpdated.Status.State.Final() {
+			h.logger().DebugContext(ctx, "Final state reached", "task_id", event.StatusUpdated.ID)
+			return
+		}
 	}
 }
 


### PR DESCRIPTION
This pull request introduces a small but important change to the `writeSSE` method in `handler.go`. The change ensures that when an event's status reaches a final state, a debug log is generated, and the method returns early.

* [`handler.go`](diffhunk://#diff-0eb779b9e49d8e44b0f36923fdb8d87d5ee024f886eefc45deec4ec88380a087R714-R717): Added a check for `event.StatusUpdated.Status.State.Final()` to log a debug message and return early when the final state is reached.